### PR TITLE
fix: align weather conditions description with other pages

### DIFF
--- a/essentials/weather-conditions.mdx
+++ b/essentials/weather-conditions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Weather conditions and icons
-description: Learn about the different weather conditions and icons available in the Current Weather Data API, and how to use them in your applications.
+description: Understand weather condition codes, icons, and how to use them in your application.
 ---
 
 The Current Weather Data API returns weather conditions as part of the `weather` array in the response.


### PR DESCRIPTION
This pull request makes a minor update to the documentation for weather conditions and icons, clarifying the description to focus on weather condition codes and their usage in applications.